### PR TITLE
Redo autoChangeAOP counting system

### DIFF
--- a/server.lua
+++ b/server.lua
@@ -246,28 +246,32 @@ end)
 Citizen.CreateThread(function()
     while autoChangeAOP do
 		local players = GetPlayers()
-		for a = 1, #players do
-			if players[a] > "30" then -- over 30
-				FaxCurAOP = ACAOPOver30
-				SetMapName("RP : " .. FaxCurAOP)
-				TriggerEvent("AOP:Sync")
-			elseif players[a] < "5" then -- under 5
-				FaxCurAOP = ACAOPUnder5
-				SetMapName("RP : " .. FaxCurAOP)
-				TriggerEvent("AOP:Sync")
-			elseif players[a] < "10" then -- under 10
-				FaxCurAOP = ACAOPUnder10
-				SetMapName("RP : " .. FaxCurAOP)
-				TriggerEvent("AOP:Sync")
-			elseif players[a] < "20" then -- under 20
-				FaxCurAOP = ACAOPUnder20
-				SetMapName("RP : " .. FaxCurAOP)
-				TriggerEvent("AOP:Sync")
-			elseif players[a] < "30" then -- under 30
-				FaxCurAOP = ACAOPUnder30
-				SetMapName("RP : " .. FaxCurAOP)
-				TriggerEvent("AOP:Sync")
-			end
+		local plcount = 0
+
+		for _, player in pairs(players) do
+			plcount = plcount + 1
+		end
+
+		if plcount > 30 then -- over 30
+			FaxCurAOP = ACAOPOver30
+			SetMapName("RP : " .. FaxCurAOP)
+			TriggerEvent("AOP:Sync")
+		elseif plcount < 5 then -- under 5
+			FaxCurAOP = ACAOPUnder5
+			SetMapName("RP : " .. FaxCurAOP)
+			TriggerEvent("AOP:Sync")
+		elseif plcount < 10 then -- under 10
+			FaxCurAOP = ACAOPUnder10
+			SetMapName("RP : " .. FaxCurAOP)
+			TriggerEvent("AOP:Sync")
+		elseif plcount < 20 then -- under 20
+			FaxCurAOP = ACAOPUnder20
+			SetMapName("RP : " .. FaxCurAOP)
+			TriggerEvent("AOP:Sync")
+		elseif plcount < 30 then -- under 30
+			FaxCurAOP = ACAOPUnder30
+			SetMapName("RP : " .. FaxCurAOP)
+			TriggerEvent("AOP:Sync")
 		end
 		TriggerEvent("AOP:Sync")
 		Citizen.Wait(90 * 1000)


### PR DESCRIPTION
Players[a] was returning the player's server ID. For example, when I connected to my dev server players[a] returned 8 even though I was the only one on. Instead of using the last player's id in the loop and executing AOP:Sync numerous times, the modified code only fires two server side events. The code also now compares an int with an int instead of a string with a string.

TLDR: Loop now counts players instead of checking largest server ID. Script now compares an int with an int instead of a string with a string.